### PR TITLE
Refresh 토큰 으로 Access, Refresh 토큰 재생성하는 기능 완료

### DIFF
--- a/Application/src/main/java/practice/application/controllers/MemberController.java
+++ b/Application/src/main/java/practice/application/controllers/MemberController.java
@@ -84,4 +84,22 @@ public class MemberController {
     public MemberLogoutResponseDTO logoutMember(@RequestBody MemberLogoutRequestDTO logoutRequestDTO) {
         return memberService.logout(logoutRequestDTO);
     }
+
+    /**
+     * Refresh 토큰으로 Access, Refresh 토큰 재생성해 제공하는 endpoint
+     *
+     * @param regenerateTokenRequestDTO 토큰 재생성 요청용 {@code DTO}
+     * @return {@link RegenerateTokenResponseDTO}
+     * @see MemberService#regenerateTokensViaRefreshToken(String)
+     */
+    @PatchMapping("/re-generate-token")
+    public RegenerateTokenResponseDTO regenerateTokens(
+            @RequestBody RegenerateTokenRequestDTO regenerateTokenRequestDTO
+    ) {
+        String givenRefreshToken = regenerateTokenRequestDTO.getRefreshToken();
+
+        TokenContainer tokens = memberService.regenerateTokensViaRefreshToken(givenRefreshToken);
+
+        return new RegenerateTokenResponseDTO(tokens);
+    }
 }

--- a/Application/src/main/java/practice/application/models/DTO/MemberLoginRequestDTO.java
+++ b/Application/src/main/java/practice/application/models/DTO/MemberLoginRequestDTO.java
@@ -9,8 +9,8 @@ public class MemberLoginRequestDTO {
 
     private String password;
 
-    public MemberLoginRequestDTO(String username, String password) {
-        this.email = username;
+    public MemberLoginRequestDTO(String email, String password) {
+        this.email = email;
         this.password = password;
     }
 

--- a/Application/src/main/java/practice/application/models/DTO/RegenerateTokenRequestDTO.java
+++ b/Application/src/main/java/practice/application/models/DTO/RegenerateTokenRequestDTO.java
@@ -1,0 +1,16 @@
+package practice.application.models.DTO;
+
+import lombok.Data;
+import practice.application.controllers.MemberController;
+import practice.application.service.MemberService;
+
+/**
+ * Refresh 토큰으로 Access, Refresh 재성하는 요청 {@code DTO}
+ *
+ * @see MemberService#regenerateTokensViaRefreshToken
+ * @see MemberController#regenerateTokens
+ */
+@Data
+public class RegenerateTokenRequestDTO {
+    private String refreshToken;
+}

--- a/Application/src/main/java/practice/application/models/DTO/RegenerateTokenResponseDTO.java
+++ b/Application/src/main/java/practice/application/models/DTO/RegenerateTokenResponseDTO.java
@@ -1,0 +1,17 @@
+package practice.application.models.DTO;
+
+import lombok.Data;
+
+/**
+ * Refresh 토큰으로 Access, Refresh 재성하는 요청 응답용 {@code DTO}
+ *
+ * @see RegenerateTokenRequestDTO
+ */
+@Data
+public class RegenerateTokenResponseDTO {
+    private TokenContainer tokens;
+
+    public RegenerateTokenResponseDTO(TokenContainer tokens) {
+        this.tokens = tokens;
+    }
+}

--- a/Application/src/main/java/practice/application/repositories/MemberRepository.java
+++ b/Application/src/main/java/practice/application/repositories/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Boolean existsByEmail(String email);
 
     Optional<MemberEntity> findByEmail(String email);
+
+    Optional<MemberEntity> findByRefreshToken(String refreshToken);
 }

--- a/Application/src/main/java/practice/application/service/MemberService.java
+++ b/Application/src/main/java/practice/application/service/MemberService.java
@@ -124,4 +124,29 @@ public class MemberService {
                 "성공적으로 로그아웃 되었습니다.", "Refresh token [" + refreshToken + "] has been expired.");
     }
 
+    /**
+     * 주어진 {@code refreshToken} 맞는 유저 골라서 Access, Refresh 토큰 재생성하는 메서드.
+     * <p>
+     * 유저 찾으면 재생성된 Refresh 토큰 DB 에 저장함.
+     *
+     * @param refreshToken 리프래쉬 토큰 {@code (String)}
+     * @return {@link TokenContainer}
+     * @throws NotFoundException 주어진 토큰에 해당하는 멤버 못찾으면 throw
+     */
+    @Transactional
+    public TokenContainer regenerateTokensViaRefreshToken(String refreshToken) {
+        MemberEntity member = memberRepository
+                .findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new NotFoundException("주어진 토큰과 매칭되는 계정이 없습니다."));
+
+        // 애초에 토큰으로 멤버를 찾으므로 이 아래는 매칭되는 멤버가 반드시 존재함
+        // --> 주어진 토큰이랑 멤버에 저장된 토큰은 반드시 일치한다. 굳이 확인할 필요 없다.
+        // 그냥 refreshToken 말고 더 정보가 없는 이상 더 좋은 솔루션은 모르겠음
+
+        // 토큰 재생성 후 멤버 정보로 다시 저장
+        TokenContainer newTokens = jwtUtil.createTokens(member);
+        member.setRefreshToken(newTokens.getRefreshToken());
+
+        return newTokens;
+    }
 }

--- a/Application/src/test/java/practice/application/service/MemberServiceTest.java
+++ b/Application/src/test/java/practice/application/service/MemberServiceTest.java
@@ -171,6 +171,10 @@ class MemberServiceTest {
     @Order(6)
     @Transactional
     public void regenerateTokenViaRefreshTokenTest() throws Exception {
+
+        // 주어진 토큰으로 매칭 안되면 NotFoundException throw
+        assertThrows(NotFoundException.class, () -> memberService.regenerateTokensViaRefreshToken("아주 이상한 토큰"));
+
         // 토큰 줘서 서비스가 뱉어낸 결과
         TokenContainer regeneratedTokens = memberService.regenerateTokensViaRefreshToken(refreshToken);
 
@@ -185,6 +189,5 @@ class MemberServiceTest {
             assertNotNull(regeneratedTokens.getRefreshToken());
             assertEquals(member.getRefreshToken(), regeneratedTokens.getRefreshToken());
         });
-
     }
 }

--- a/Application/src/test/java/practice/application/service/MemberServiceTest.java
+++ b/Application/src/test/java/practice/application/service/MemberServiceTest.java
@@ -39,6 +39,7 @@ class MemberServiceTest {
 
     private final String testingEmail = "k12002@nate.com";
     private final String testingPassword = "1234";
+    private String refreshToken = null;
 
     @BeforeEach
     void setUp() {  // 각 테스트마다 필요한 이메일 넣는 메서드, 이미 넣어져 있으면 넘어감
@@ -51,6 +52,11 @@ class MemberServiceTest {
         catch (DuplicateEmailException e) {
             // User already saved in DB
         }
+
+        // refresh 토큰 테스트 위해 DB 기록되는 토큰 가져와놓기
+        MemberLoginRequestDTO memberLoginRequestDTO = new MemberLoginRequestDTO(testingEmail, testingPassword);
+        TokenContainer tokens = memberService.loginWithTokenContainer(memberLoginRequestDTO);
+        refreshToken = tokens.getRefreshToken();
     }
 
     @Test
@@ -158,5 +164,27 @@ class MemberServiceTest {
 
         // 없어졌는지 확인
         assertNull(member.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("Refresh 토큰 주어지면 access, refresh 잘 생성하고 DB 에 잘 update 되는지")
+    @Order(6)
+    @Transactional
+    public void regenerateTokenViaRefreshTokenTest() throws Exception {
+        // 토큰 줘서 서비스가 뱉어낸 결과
+        TokenContainer regeneratedTokens = memberService.regenerateTokensViaRefreshToken(refreshToken);
+
+        // 토큰 제대로 저장됐는지 확인하기 위해 멤버 꺼내기
+        MemberEntity member = memberRepository
+                .findByEmail(testingEmail)
+                .orElseThrow(NotFoundException::new);
+
+        // 서비스가 뱉어낸 결과 null 아니고 refresh 토큰 제대로 다시 저장 됐는지 확인
+        assertAll(() -> {
+            assertNotNull(regeneratedTokens.getAccessToken());
+            assertNotNull(regeneratedTokens.getRefreshToken());
+            assertEquals(member.getRefreshToken(), regeneratedTokens.getRefreshToken());
+        });
+
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 

`access` 토큰 만료되어서 `refresh` 토큰으로 다시 발급해주는 기능 추가했습니다.


## 👩‍💻 요구 사항과 구현 내용 

### Controller
- `MemberController#regenerateTokens` 메서드로 해당 기능 endpoint 추가했습니다. `(Http method : Patch)`
- 해당 endpoint 를 위한 DTO 추가했습니다.

### Repository

- 해당 기능을 위해 `MemberRepository#findByRefreshToken` 메서드 추가했습니다.

### Service
- 해당 기능을 위해 `MemberService#regenerateTokensViaRefreshToken` 메서드 추가했습니다.

### Test code
- 주어진 `refresh` 토큰으로 `access`, `refresh` 토큰이 잘 생성되고 `DB` 에 저장되는지 확인하는 테스트 코드 추가했습니다.


## ✅ 피드백 반영사항 

## ✅ PR 포인트 & 궁금한 점 
